### PR TITLE
removed unused async keyword

### DIFF
--- a/apps/web/src/components/CreateTopicModal/index.tsx
+++ b/apps/web/src/components/CreateTopicModal/index.tsx
@@ -36,12 +36,12 @@ const CreateTopicModal = () => {
     }
   }, [status]);
 
-  const closeTopicModal = async (event: any) => {
+  const closeTopicModal = (event: any) => {
     if (event) event.preventDefault();
     dispatch(setTopicModal(false));
   };
 
-  const handleCreate = useCallback(async (values: CreateTopicData) => {
+  const handleCreate = useCallback((values: CreateTopicData) => {
     handleAddTopic({ ...values, author: user?.id });
   }, []);
 


### PR DESCRIPTION
using an async function without await may not be necessary and can lead to confusion for other developers who may expect asynchronous behavior. It is generally recommended to use async/await together to ensure clear and concise code that properly handles asynchronous operations.